### PR TITLE
Update exploratory-analysis.ipynb - Added 'numeric_only=True' to df.groupby("region").mean()

### DIFF
--- a/notebooks/lesson1/exploratory-analysis.ipynb
+++ b/notebooks/lesson1/exploratory-analysis.ipynb
@@ -522,7 +522,7 @@
       ],
       "source": [
         "# Specific operations by method. Like .mean()\n",
-        "df.groupby(\"region\").mean()"
+        "df.groupby(\"region\").mean(numeric_only=True)"
       ]
     }
   ],


### PR DESCRIPTION
Since Pandas 2.0.0, **numeric_only** defaults to **False** in the groupby("").mean() method.
This gives an error as there are non-numeric columns.